### PR TITLE
add ceph-common to kube-controller-manager snap

### DIFF
--- a/snap/kube-controller-manager.yaml
+++ b/snap/kube-controller-manager.yaml
@@ -7,14 +7,14 @@ confinement: strict
 
 apps:
   daemon:
-    command: run-with-config-args kube-controller-manager
+    command: run-with-config-args kube-controller-manager-wrapper
     daemon: simple
     plugs:
         - network
         - network-bind
         - home
   kube-controller-manager:
-    command: kube-controller-manager
+    command: kube-controller-manager-wrapper
     plugs:
         - network
         - network-bind
@@ -23,8 +23,11 @@ parts:
   kube-controller-manager:
     plugin: dump
     source: .
+    stage-packages:
+      - ceph-common
     prepare: |
       set -eu
       cp $KUBE_SNAP_BINS/kube-controller-manager .
       cp $KUBE_SNAP_ROOT/shared/run-with-config-args .
+      cp $KUBE_SNAP_ROOT/kube-controller-manager/kube-controller-manager-wrapper .
       $KUBE_SNAP_ROOT/shared/generate-configure-hook kube-controller-manager

--- a/snap/kube-controller-manager/kube-controller-manager-wrapper
+++ b/snap/kube-controller-manager/kube-controller-manager-wrapper
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -eu
+
+# Set CEPH_CONF so `rbd` doesn't try to look in /etc/ceph and error out
+export CEPH_CONF="$SNAP_USER_DATA/ceph/ceph.conf"
+
+exec "$SNAP/kube-controller-manager" "$@"


### PR DESCRIPTION
This is necessary for kube-controller-manager to provision volumes
with `rbd`.

Fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/258