### PR TITLE
support multiple platforms

### DIFF
--- a/snap/Makefile
+++ b/snap/Makefile
@@ -1,4 +1,5 @@
 KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable.txt)
+KUBE_ARCH=amd64
 
 ifndef VERBOSE
 	MAKEFLAGS += --no-print-directory
@@ -10,32 +11,37 @@ build = ./build-scripts/build
 
 .PHONY: $(targets)
 
+all-arch:
+	for arch in amd64 arm arm64 ppc64le s390x ; do \
+		make KUBE_ARCH=$$arch default; \
+	done
+
 default:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} $(targets)
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} $(targets)
 
 clean:
 	@rm -rf build
 
 kubectl:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kubectl
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubectl
 
 kubeadm:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kubeadm
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubeadm
 
 kubefed:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kubefed
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubefed
 
 kube-apiserver:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kube-apiserver
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kube-apiserver
 
 kube-controller-manager:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kube-controller-manager
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kube-controller-manager
 
 kube-scheduler:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kube-scheduler
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kube-scheduler
 
 kubelet:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kubelet
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubelet
 
 kube-proxy:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kube-proxy
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kube-proxy

--- a/snap/build-scripts/build
+++ b/snap/build-scripts/build
@@ -11,7 +11,7 @@ if [ -z "$KUBE_SNAP_BINS" ]; then
   cd $KUBE_SNAP_BINS
   for app in $apps; do
     curl -LO \
-      https://dl.k8s.io/${KUBE_VERSION}/bin/linux/amd64/$app
+      https://dl.k8s.io/${KUBE_VERSION}/bin/linux/${KUBE_ARCH}/$app
     chmod +x $app
   done
   cd ../../..
@@ -28,6 +28,7 @@ for app in $apps; do
   mkdir -p $build_dir
 
   sed "s/KUBE_VERSION/${KUBE_VERSION:1}/g" $app.yaml > $build_dir/snapcraft.yaml
+  sed -i "s/KUBE_ARCH/${KUBE_ARCH}/g" $build_dir/snapcraft.yaml
 
   (cd $build_dir && snapcraft)
   mv $build_dir/*.snap build

--- a/snap/kube-apiserver.yaml
+++ b/snap/kube-apiserver.yaml
@@ -1,4 +1,5 @@
 name: kube-apiserver
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: kube-apiserver
 description: kube-apiserver

--- a/snap/kube-controller-manager.yaml
+++ b/snap/kube-controller-manager.yaml
@@ -1,4 +1,5 @@
 name: kube-controller-manager
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: kube-controller-manager
 description: kube-controller-manager

--- a/snap/kube-proxy.yaml
+++ b/snap/kube-proxy.yaml
@@ -1,4 +1,5 @@
 name: kube-proxy
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: Kubernetes network proxy runs on each node.
 description: |

--- a/snap/kube-scheduler.yaml
+++ b/snap/kube-scheduler.yaml
@@ -1,4 +1,5 @@
 name: kube-scheduler
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: kube-scheduler controls the Kubernetes cluster manager.
 description: |

--- a/snap/kubeadm.yaml
+++ b/snap/kubeadm.yaml
@@ -1,4 +1,5 @@
 name: kubeadm
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: easily bootstrap a secure Kubernetes cluster
 description: |

--- a/snap/kubectl.yaml
+++ b/snap/kubectl.yaml
@@ -1,4 +1,5 @@
 name: kubectl
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: kubectl controls the Kubernetes cluster manager.
 description: |

--- a/snap/kubefed.yaml
+++ b/snap/kubefed.yaml
@@ -1,4 +1,5 @@
 name: kubefed
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: kubefed controls the Kubernetes cluster federation manager.
 description: |

--- a/snap/kubelet.yaml
+++ b/snap/kubelet.yaml
@@ -1,4 +1,5 @@
 name: kubelet
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: kubelet is the primary “node agent” that runs on each node in Kubernetes.
 description: |


### PR DESCRIPTION
**DO NOT MERGE**

This is broken in at least one way: kube-controller-manager pulls in ceph-common with `stage-packages`, but this doesn't take into account the `architectures` list.

Additionally, during the build, the following warnings arose for kubelet and kubefed:
```Unable to determine library dependencies for b'/home/rye/src/release/snap/build/kubelet/prime/kubelet'```

@Cynerva 