### PR TITLE
Snaps multiarch support

### DIFF
--- a/snap/Makefile
+++ b/snap/Makefile
@@ -1,4 +1,5 @@
 KUBE_VERSION=$(shell curl -L https://dl.k8s.io/release/stable.txt)
+KUBE_ARCH=amd64
 
 ifndef VERBOSE
 	MAKEFLAGS += --no-print-directory
@@ -10,35 +11,40 @@ build = ./build-scripts/build
 
 .PHONY: $(targets)
 
+all-arch:
+	for arch in amd64 arm arm64 ppc64le s390x ; do \
+		make KUBE_ARCH=$$arch default; \
+	done
+
 default:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} $(targets)
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} $(targets)
 
 clean:
 	@rm -rf build
 
 kubectl:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kubectl
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubectl
 
 kubeadm:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kubeadm
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubeadm
 
 kubefed:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kubefed
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubefed
 
 kube-apiserver:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kube-apiserver
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kube-apiserver
 
 kube-controller-manager:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kube-controller-manager
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kube-controller-manager
 
 kube-scheduler:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kube-scheduler
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kube-scheduler
 
 kubelet:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kubelet
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubelet
 
 kube-proxy:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kube-proxy
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kube-proxy
 
 kubernetes-test:
-	@KUBE_VERSION=${KUBE_VERSION} ${build} kubernetes-test
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubernetes-test

--- a/snap/Makefile
+++ b/snap/Makefile
@@ -11,40 +11,35 @@ build = ./build-scripts/build
 
 .PHONY: $(targets)
 
-all-arch:
-	for arch in amd64 arm arm64 ppc64le s390x ; do \
-		make KUBE_ARCH=$$arch default; \
-	done
-
 default:
-	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} $(targets)
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH="${KUBE_ARCH}" ${build} $(targets)
 
 clean:
 	@rm -rf build
 
 kubectl:
-	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubectl
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH="${KUBE_ARCH}" ${build} kubectl
 
 kubeadm:
-	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubeadm
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH="${KUBE_ARCH}" ${build} kubeadm
 
 kubefed:
-	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubefed
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH="${KUBE_ARCH}" ${build} kubefed
 
 kube-apiserver:
-	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kube-apiserver
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH="${KUBE_ARCH}" ${build} kube-apiserver
 
 kube-controller-manager:
-	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kube-controller-manager
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH="${KUBE_ARCH}" ${build} kube-controller-manager
 
 kube-scheduler:
-	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kube-scheduler
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH="${KUBE_ARCH}" ${build} kube-scheduler
 
 kubelet:
-	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubelet
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH="${KUBE_ARCH}" ${build} kubelet
 
 kube-proxy:
-	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kube-proxy
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH="${KUBE_ARCH}" ${build} kube-proxy
 
 kubernetes-test:
-	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH=${KUBE_ARCH} ${build} kubernetes-test
+	@KUBE_VERSION=${KUBE_VERSION} KUBE_ARCH="${KUBE_ARCH}" ${build} kubernetes-test

--- a/snap/build-scripts/build
+++ b/snap/build-scripts/build
@@ -11,12 +11,19 @@ if [ -z "$KUBE_SNAP_BINS" ]; then
   (cd $KUBE_SNAP_BINS
     for app in $apps; do
       if [ "$app" = "kubernetes-test" ]; then
+        echo "Fetching $app $KUBE_VERSION"
         curl -LO \
           https://dl.k8s.io/${KUBE_VERSION}/kubernetes-test.tar.gz
       else
-        curl -LO \
-          https://dl.k8s.io/${KUBE_VERSION}/bin/linux/${KUBE_ARCH}/$app
-        chmod +x $app
+        for arch in $KUBE_ARCH; do
+          mkdir -p $arch
+          (cd $arch
+            echo "Fetching $app $KUBE_VERSION $arch"
+            curl -LO \
+              https://dl.k8s.io/${KUBE_VERSION}/bin/linux/$arch/$app
+            chmod +x $app
+          )
+        done
       fi
     done
   )
@@ -26,15 +33,17 @@ export KUBE_SNAP_ROOT="$(readlink -f .)"
 export KUBE_SNAP_BINS="$(readlink -f $KUBE_SNAP_BINS)"
 
 for app in $apps; do
-  echo "Building $app $KUBE_VERSION from $KUBE_SNAP_BINS"
+  for arch in $KUBE_ARCH; do
+    echo "Building $app $KUBE_VERSION for $arch from $KUBE_SNAP_BINS"
 
-  build_dir=build/$app
-  rm -rf $build_dir
-  mkdir -p $build_dir
+    build_dir=build/$app
+    rm -rf $build_dir
+    mkdir -p $build_dir
 
-  sed "s/KUBE_VERSION/${KUBE_VERSION:1}/g" $app.yaml > $build_dir/snapcraft.yaml
-  sed -i "s/KUBE_ARCH/${KUBE_ARCH}/g" $build_dir/snapcraft.yaml
+    sed "s/KUBE_VERSION/${KUBE_VERSION:1}/g" $app.yaml > $build_dir/snapcraft.yaml
+    sed -i "s/KUBE_ARCH/$arch/g" $build_dir/snapcraft.yaml
 
-  (cd $build_dir && snapcraft)
-  mv $build_dir/*.snap build
+    (cd $build_dir && snapcraft)
+    mv $build_dir/*.snap build
+  done
 done

--- a/snap/build-scripts/build
+++ b/snap/build-scripts/build
@@ -15,7 +15,7 @@ if [ -z "$KUBE_SNAP_BINS" ]; then
           https://dl.k8s.io/${KUBE_VERSION}/kubernetes-test.tar.gz
       else
         curl -LO \
-          https://dl.k8s.io/${KUBE_VERSION}/bin/linux/amd64/$app
+          https://dl.k8s.io/${KUBE_VERSION}/bin/linux/${KUBE_ARCH}/$app
         chmod +x $app
       fi
     done
@@ -33,6 +33,7 @@ for app in $apps; do
   mkdir -p $build_dir
 
   sed "s/KUBE_VERSION/${KUBE_VERSION:1}/g" $app.yaml > $build_dir/snapcraft.yaml
+  sed -i "s/KUBE_ARCH/${KUBE_ARCH}/g" $build_dir/snapcraft.yaml
 
   (cd $build_dir && snapcraft)
   mv $build_dir/*.snap build

--- a/snap/kube-apiserver.yaml
+++ b/snap/kube-apiserver.yaml
@@ -26,6 +26,6 @@ parts:
     source: .
     prepare: |
       set -eu
-      cp $KUBE_SNAP_BINS/kube-apiserver .
+      cp $KUBE_SNAP_BINS/KUBE_ARCH/kube-apiserver .
       cp $KUBE_SNAP_ROOT/shared/run-with-config-args .
       $KUBE_SNAP_ROOT/shared/generate-configure-hook kube-apiserver

--- a/snap/kube-apiserver.yaml
+++ b/snap/kube-apiserver.yaml
@@ -1,4 +1,5 @@
 name: kube-apiserver
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: kube-apiserver
 description: kube-apiserver

--- a/snap/kube-controller-manager.yaml
+++ b/snap/kube-controller-manager.yaml
@@ -1,4 +1,5 @@
 name: kube-controller-manager
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: kube-controller-manager
 description: kube-controller-manager

--- a/snap/kube-controller-manager.yaml
+++ b/snap/kube-controller-manager.yaml
@@ -25,10 +25,10 @@ parts:
     plugin: dump
     source: .
     stage-packages:
-      - ceph-common
+      - ceph-common:KUBE_ARCH
     prepare: |
       set -eu
-      cp $KUBE_SNAP_BINS/kube-controller-manager .
+      cp $KUBE_SNAP_BINS/KUBE_ARCH/kube-controller-manager .
       cp $KUBE_SNAP_ROOT/shared/run-with-config-args .
       cp $KUBE_SNAP_ROOT/kube-controller-manager/kube-controller-manager-wrapper .
       $KUBE_SNAP_ROOT/shared/generate-configure-hook kube-controller-manager

--- a/snap/kube-proxy.yaml
+++ b/snap/kube-proxy.yaml
@@ -26,6 +26,6 @@ parts:
     source: .
     prepare: |
       set -eu
-      cp $KUBE_SNAP_BINS/kube-proxy .
+      cp $KUBE_SNAP_BINS/KUBE_ARCH/kube-proxy .
       cp $KUBE_SNAP_ROOT/shared/run-with-config-args .
       $KUBE_SNAP_ROOT/shared/generate-configure-hook kube-proxy

--- a/snap/kube-proxy.yaml
+++ b/snap/kube-proxy.yaml
@@ -1,4 +1,5 @@
 name: kube-proxy
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: Kubernetes network proxy runs on each node.
 description: |

--- a/snap/kube-scheduler.yaml
+++ b/snap/kube-scheduler.yaml
@@ -1,4 +1,5 @@
 name: kube-scheduler
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: kube-scheduler controls the Kubernetes cluster manager.
 description: |

--- a/snap/kube-scheduler.yaml
+++ b/snap/kube-scheduler.yaml
@@ -28,6 +28,6 @@ parts:
     source: .
     prepare: |
       set -eu
-      cp $KUBE_SNAP_BINS/kube-scheduler .
+      cp $KUBE_SNAP_BINS/KUBE_ARCH/kube-scheduler .
       cp $KUBE_SNAP_ROOT/shared/run-with-config-args .
       $KUBE_SNAP_ROOT/shared/generate-configure-hook kube-scheduler

--- a/snap/kubeadm.yaml
+++ b/snap/kubeadm.yaml
@@ -17,4 +17,4 @@ parts:
     source: .
     prepare: |
       set -eu
-      cp $KUBE_SNAP_BINS/kubeadm .
+      cp $KUBE_SNAP_BINS/KUBE_ARCH/kubeadm .

--- a/snap/kubeadm.yaml
+++ b/snap/kubeadm.yaml
@@ -1,4 +1,5 @@
 name: kubeadm
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: easily bootstrap a secure Kubernetes cluster
 description: |

--- a/snap/kubectl.yaml
+++ b/snap/kubectl.yaml
@@ -18,4 +18,4 @@ parts:
     source: .
     prepare: |
       set -eu
-      cp $KUBE_SNAP_BINS/kubectl .
+      cp $KUBE_SNAP_BINS/KUBE_ARCH/kubectl .

--- a/snap/kubectl.yaml
+++ b/snap/kubectl.yaml
@@ -1,4 +1,5 @@
 name: kubectl
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: kubectl controls the Kubernetes cluster manager.
 description: |

--- a/snap/kubefed.yaml
+++ b/snap/kubefed.yaml
@@ -18,4 +18,4 @@ parts:
     source: .
     prepare: |
       set -eu
-      cp $KUBE_SNAP_BINS/kubefed .
+      cp $KUBE_SNAP_BINS/KUBE_ARCH/kubefed .

--- a/snap/kubefed.yaml
+++ b/snap/kubefed.yaml
@@ -1,4 +1,5 @@
 name: kubefed
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: kubefed controls the Kubernetes cluster federation manager.
 description: |

--- a/snap/kubelet.yaml
+++ b/snap/kubelet.yaml
@@ -1,4 +1,5 @@
 name: kubelet
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: kubelet is the primary “node agent” that runs on each node in Kubernetes.
 description: |

--- a/snap/kubelet.yaml
+++ b/snap/kubelet.yaml
@@ -25,6 +25,6 @@ parts:
     source: .
     prepare: |
       set -eu
-      cp $KUBE_SNAP_BINS/kubelet .
+      cp $KUBE_SNAP_BINS/KUBE_ARCH/kubelet .
       cp $KUBE_SNAP_ROOT/shared/run-with-config-args .
       $KUBE_SNAP_ROOT/shared/generate-configure-hook kubelet

--- a/snap/kubernetes-test.yaml
+++ b/snap/kubernetes-test.yaml
@@ -1,4 +1,5 @@
 name: kubernetes-test
+architectures: ['KUBE_ARCH']
 version: 'KUBE_VERSION'
 summary: tests for kubernetes
 description: |
@@ -25,8 +26,8 @@ parts:
       mkdir build-temp
       (cd build-temp
         tar -xf "$KUBE_SNAP_BINS/kubernetes-test.tar.gz"
-        mv kubernetes/platforms/linux/amd64/e2e.test ..
-        mv kubernetes/platforms/linux/amd64/ginkgo ..
+        mv kubernetes/platforms/linux/KUBE_ARCH/e2e.test ..
+        mv kubernetes/platforms/linux/KUBE_ARCH/ginkgo ..
       )
       rm -rf build-temp
       chmod +rx e2e.test


### PR DESCRIPTION
@wwwtyro Don't merge, this needs testing.

Rebased from your rye/snaps-multiarch branch and made a few changes:
* Allow multiple architectures to be passed through `KUBE_ARCH`
* Update kube-controller-manager to pull in `ceph-common:KUBE_ARCH`