### PR TITLE
Fix snap configuration not properly handling boolean false values

### DIFF
--- a/snap/shared/generate-configure-hook
+++ b/snap/shared/generate-configure-hook
@@ -24,7 +24,9 @@ function config-arg-bool {
   value=$(snapctl get $key)
   if [ "$value" = 'true' ]; then
     echo "--$key" >> $SNAP_DATA/args
-  elif [ -n "$value" ] && [ "$value" != 'false' ]; then
+  elif [ "$value" = 'false' ]; then
+    echo "--$key=false" >> $SNAP_DATA/args
+  elif [ -n "$value" ]; then
     >&2 echo "Invalid value for $key: $value, expected true or false"
     exit 1
   fi


### PR DESCRIPTION
Fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/314

The resultings args file for kubelet looks like this, for example:
```
--address "0.0.0.0"
--allow-privileged
--anonymous-auth=false
--client-ca-file "/root/cdk/ca.crt"
--cluster-dns "10.152.183.10"
--cluster-domain "cluster.local"
--kubeconfig "/root/cdk/kubeconfig"
--logtostderr
--network-plugin "cni"
--port 10250
--require-kubeconfig
--tls-cert-file "/root/cdk/server.crt"
--tls-private-key-file "/root/cdk/server.key"
--v 0
```