### PR TITLE
Fix configure hook for 1.10 by converting underscores to dashes

### DIFF
--- a/snap/shared/generate-configure-hook
+++ b/snap/shared/generate-configure-hook
@@ -11,21 +11,28 @@ set -eu
 
 rm -f $SNAP_DATA/args
 
+function option-to-key {
+  option=$1
+  echo $option | sed 's/_/-/g'
+}
+
 function config-arg {
-  key=$1
+  option=$1
+  key=$(option-to-key $option)
   value=$(snapctl get -t $key)
   if [ "$value" != 'null' ]; then
-    echo "--$key $value" >> $SNAP_DATA/args
+    echo "--$option $value" >> $SNAP_DATA/args
   fi
 }
 
 function config-arg-bool {
-  key=$1
+  option=$1
+  key=$(option-to-key $option)
   value=$(snapctl get $key)
   if [ "$value" = 'true' ]; then
-    echo "--$key" >> $SNAP_DATA/args
+    echo "--$option" >> $SNAP_DATA/args
   elif [ "$value" = 'false' ]; then
-    echo "--$key=false" >> $SNAP_DATA/args
+    echo "--$option=false" >> $SNAP_DATA/args
   elif [ -n "$value" ]; then
     >&2 echo "Invalid value for $key: $value, expected true or false"
     exit 1
@@ -36,11 +43,11 @@ EOF
 
 ./$app -h 2>&1 | grep '\-\-' | perl -pe 's/.*?--(\S+ \S*).*/\1/' | while read line; do
   if [ $(echo "$line" | wc -w) -eq 2 ]; then
-    key=$(echo "$line" | cut -d ' ' -f 1)
-    echo "config-arg $key" >> meta/hooks/configure
+    option=$(echo "$line" | cut -d ' ' -f 1)
+    echo "config-arg $option" >> meta/hooks/configure
   else
-    key=$line
-    echo "config-arg-bool $key" >> meta/hooks/configure
+    option=$line
+    echo "config-arg-bool $option" >> meta/hooks/configure
   fi
 done
 


### PR DESCRIPTION
Fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/524

This PR fixes an error we saw in 1.10:
```
- Run configure hook of "kube-controller-manager" snap if present (run hook "configure": error: error running snapctl: invalid option name: "concurrent_rc_syncs")
```

Underscores in snap config keys are not valid ([link to regex](https://github.com/snapcore/snapd/blob/f82b54f6414817823f39c8bf0d4b7ec4e3629b63/overlord/configstate/config/helpers.go#L34)). We generate our configure hooks automatically from the help output of kube-controller-manager. The help output in 1.10 has changed to show `concurrent-rc-syncs` as `concurrent_rc_syncs`.

In 1.9 and prior, both `--concurrent-rc-syncs` and `--concurrent_rc_syncs` were accepted and used. As of 1.10, only `--concurrent_rc_syncs` works.

The fix is to have generate-configure-hook convert underscores to dashes for snap config keys. So this:
```
snap set kube-controller-manager concurrent-rc-syncs=4
```

maps to this:

```
kube-controller-manager --concurrent_rc_syncs 4
```