### PR TITLE
Source /root/cdk/kube.env in daemon wrappers

### DIFF
--- a/snap/kube-apiserver.yaml
+++ b/snap/kube-apiserver.yaml
@@ -8,7 +8,7 @@ confinement: strict
 
 apps:
   daemon:
-    command: run-with-config-args kube-apiserver
+    command: run-with-config-args kube-apiserver-wrapper
     daemon: simple
     plugs:
         - home
@@ -28,4 +28,5 @@ parts:
       set -eu
       cp $KUBE_SNAP_BINS/$KUBE_ARCH/kube-apiserver .
       cp $KUBE_SNAP_ROOT/shared/run-with-config-args .
+      cp $KUBE_SNAP_ROOT/kube-apiserver/kube-apiserver-wrapper .
       $KUBE_SNAP_ROOT/shared/generate-configure-hook kube-apiserver

--- a/snap/kube-apiserver/kube-apiserver-wrapper
+++ b/snap/kube-apiserver/kube-apiserver-wrapper
@@ -1,12 +1,10 @@
 #!/bin/sh
 set -eu
 
-export PATH=$PATH:$SNAP/usr/sbin
-
 if [ -e /root/cdk/kube.env ]; then
     set -a  # enable auto-export
     . /root/cdk/kube.env
     set +a  # disable auto-export
 fi
 
-exec "$SNAP/kube-proxy" "$@"
+exec "$SNAP/kube-apiserver" "$@"

--- a/snap/kube-controller-manager/kube-controller-manager-wrapper
+++ b/snap/kube-controller-manager/kube-controller-manager-wrapper
@@ -4,4 +4,10 @@ set -eu
 # Set CEPH_CONF so `rbd` doesn't try to look in /etc/ceph and error out
 export CEPH_CONF="$SNAP_USER_DATA/ceph/ceph.conf"
 
+if [ -e /root/cdk/kube.env ]; then
+    set -a  # enable auto-export
+    . /root/cdk/kube.env
+    set +a  # disable auto-export
+fi
+
 exec "$SNAP/kube-controller-manager" "$@"

--- a/snap/kube-scheduler.yaml
+++ b/snap/kube-scheduler.yaml
@@ -10,7 +10,7 @@ confinement: strict
 
 apps:
   daemon:
-    command: run-with-config-args kube-scheduler
+    command: run-with-config-args kube-scheduler-wrapper
     daemon: simple
     plugs:
         - network
@@ -30,4 +30,5 @@ parts:
       set -eu
       cp $KUBE_SNAP_BINS/$KUBE_ARCH/kube-scheduler .
       cp $KUBE_SNAP_ROOT/shared/run-with-config-args .
+      cp $KUBE_SNAP_ROOT/kube-scheduler/kube-scheduler-wrapper .
       $KUBE_SNAP_ROOT/shared/generate-configure-hook kube-scheduler

--- a/snap/kube-scheduler/kube-scheduler-wrapper
+++ b/snap/kube-scheduler/kube-scheduler-wrapper
@@ -1,12 +1,10 @@
 #!/bin/sh
 set -eu
 
-export PATH=$PATH:$SNAP/usr/sbin
-
 if [ -e /root/cdk/kube.env ]; then
     set -a  # enable auto-export
     . /root/cdk/kube.env
     set +a  # disable auto-export
 fi
 
-exec "$SNAP/kube-proxy" "$@"
+exec "$SNAP/kube-scheduler" "$@"

--- a/snap/kubelet/kubelet-wrapper
+++ b/snap/kubelet/kubelet-wrapper
@@ -3,4 +3,10 @@ set -eu
 
 export HOME="/root"
 
+if [ -e /root/cdk/kube.env ]; then
+    set -a  # enable auto-export
+    . /root/cdk/kube.env
+    set +a  # disable auto-export
+fi
+
 exec "$SNAP/kubelet" "$@"


### PR DESCRIPTION
In order to pass env vars to the daemons in a generic fashion, this sources the /root/cdk/kube.env file if it exists.