### PR TITLE
Fix configure hooks incorrectly encoding some args

### DIFF
--- a/snap/shared/generate-configure-hook
+++ b/snap/shared/generate-configure-hook
@@ -19,9 +19,9 @@ function option-to-key {
 function config-arg {
   option=$1
   key=$(option-to-key $option)
-  value=$(snapctl get -t $key)
-  if [ "$value" != 'null' ]; then
-    echo "--$option $value" >> $SNAP_DATA/args
+  value=$(snapctl get $key)
+  if [ -n "$value" ]; then
+    echo "--$option=\"$value\"" >> $SNAP_DATA/args
   fi
 }
 


### PR DESCRIPTION
This fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/601 by removing `-t` from our call to `snapctl get`. This stops snapctl from doing whatever weird character escape it's doing.

There are two side effects to this change:
1. `null` and `""` values are now treated the same way. This makes it possible to clear options by setting them to empty, e.g. `snap set kubelet eviction-hard=`
2. Entries in the generated args file now contain `=`. This is just for readability.