### PR TITLE
Support dynamic kubelet config with restart-condition: always

### DIFF
--- a/snap/kubelet.yaml
+++ b/snap/kubelet.yaml
@@ -16,6 +16,7 @@ apps:
   daemon:
     command: run-with-config-args kubelet-wrapper
     daemon: simple
+    restart-condition: always  # needed for Dynamic Kubelet Config support
   kubelet:
     command: kubelet
 


### PR DESCRIPTION
Dynamic Kubelet Config works by having kubelet exit with code 0 so the parent service will restart it. We need to set `restart-condition: always` here so that we'll actually do the restart when the exit code is 0.