### PR TITLE
Add snapcraft cleanbuild

### DIFF
--- a/snap/build-scripts/build
+++ b/snap/build-scripts/build
@@ -64,7 +64,7 @@ for app in $apps; do
         -e "s/\$KUBE_VERSION/${KUBE_VERSION:1}/g" \
         -e "s/\$SNAP_ARCH/$SNAP_ARCH/g" $app.yaml > $build_dir/snapcraft.yaml
 
-    (cd $build_dir && snapcraft)
+    (cd $build_dir && snapcraft cleanbuild)
     mv $build_dir/*.snap build
   done
 done


### PR DESCRIPTION
This makes sure snaps can still be built on bionic hosts.

Signed-off-by: Adam Stokes <battlemidget@users.noreply.github.com>