### PR TITLE
Update README to not use docker-build.sh

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -2,15 +2,15 @@
 
 ## Build everything
 
-Run `./docker-build.sh` here and check for the results in the `build/` directory.
+Run `make` here and check for the results in the `build/` directory.
 
 ## Build one snap
 
-To build a specific snap, run `./docker-build.sh` with the name of the snap, e.g., for
+To build a specific snap, run `make` with the name of the snap, e.g., for
 kubectl:
 
 ```sh
-$ ./docker-build.sh kubectl
+$ make kubectl
 ```
 
 The result will again be in the `build/` directory.
@@ -20,13 +20,13 @@ The result will again be in the `build/` directory.
 Set KUBE_VERSION to build the snaps with a particular Kubernetes version, e.g.,
 
 ```sh
-$ ./docker-build.sh KUBE_VERSION=v1.5.5
+$ make KUBE_VERSION=v1.5.5
 ```
 
 ## Cleaning up
 
-Simply run `./docker-build.sh clean` to remove everything except downloaded resources:
+Simply run `make clean` to remove everything except downloaded resources:
 
 ```sh
-$ ./docker-build.sh clean
+$ make clean
 ```


### PR DESCRIPTION
#29 and #30 made direct usage of `docker-build.sh` obsolete. This updates the README to recommend using `make` instead.