### PR TITLE
Fix KUBE_VERSION and KUBE_ARCH being ignored

### DIFF
--- a/snap/Makefile
+++ b/snap/Makefile
@@ -7,7 +7,7 @@ endif
 
 targets = kubectl kube-apiserver kube-controller-manager kube-scheduler kubelet kube-proxy kubeadm kubernetes-test
 
-build = ./docker-build.sh
+build = ./build-scripts/docker-build
 
 .PHONY: $(targets)
 

--- a/snap/build-scripts/docker-build
+++ b/snap/build-scripts/docker-build
@@ -2,8 +2,8 @@
 
 docker run --rm -v "$PWD":/root/snap -w /root/snap \
        -e SNAPCRAFT_SETUP_CORE=1 \
-       -e KUBE_ARCH=amd64 \
-       -e KUBE_VERSION=$(curl -L https://dl.k8s.io/release/stable.txt) \
+       -e KUBE_ARCH=$KUBE_ARCH \
+       -e KUBE_VERSION=$KUBE_VERSION \
        -v /usr/bin/curl:/usr/bin/curl \
        -v /usr/bin/make:/usr/bin/make \
        -v /usr/share/misc/magic.mgc:/usr/share/misc/magic.mgc \


### PR DESCRIPTION
@battlemidget Looks like somewhere along the way we lost the ability to pass KUBE_VERSION and KUBE_ARCH through to the build script. It just always builds the latest stable Kubernetes (currently v1.11.3). This PR should fix it.

I also moved the docker-build.sh script into build-scripts/ to tidy up a bit, hope that's cool.