### PR TITLE
Add custom args

### DIFF
--- a/snap/shared/generate-configure-hook
+++ b/snap/shared/generate-configure-hook
@@ -39,6 +39,7 @@ function config-arg-bool {
   fi
 }
 
+echo "$(snapctl get args)" >> $SNAP_DATA/args
 EOF
 
 ./$app -h 2>&1 | grep '\-\-' | perl -pe 's/.*?--(\S+ \S*).*/\1/' | while read line; do


### PR DESCRIPTION
Thank you @Cynerva. I tested this with no major issues.

Two points worth mentioning.

1.  Right now there is no way to unset a snap config. This means that if you `snap set kubelet my-config` you cannot set it through  `snap set kubelet args="--my-config"`. We need to wait for the deleting configs support: https://forum.snapcraft.io/t/how-to-unset-snap-config/1165/3

2. I am not aware of any config length limits we may have. I just asked here: https://forum.snapcraft.io/t/configuration-in-snaps/510/3 .

Many thanks!